### PR TITLE
Add Twig cross-library namespace support

### DIFF
--- a/plugins/content_types/patternkit.inc
+++ b/plugins/content_types/patternkit.inc
@@ -173,6 +173,9 @@ function patternkit_patternkit_content_type_edit_form($form, &$form_state) {
   $conf = $form_state['conf'];
   // Get all of the module metadata from the pattern path.
   $module = _patternkit_get_metadata($subtype);
+  if (empty($module)) {
+    return $form;
+  }
 
   // Remove the title override fields.
   unset($form['override_title_markup'],

--- a/src/PatternkitDrupalTwigLib.php
+++ b/src/PatternkitDrupalTwigLib.php
@@ -13,6 +13,8 @@ class PatternkitDrupalTwigLib extends PatternkitDrupalCachedLib {
 
   private $metadata;
 
+  private $namespace;
+
   /**
    * PatternkitDrupalTwigLib constructor.
    *
@@ -23,7 +25,8 @@ class PatternkitDrupalTwigLib extends PatternkitDrupalCachedLib {
    */
   public function __construct($title, $path) {
     $this->title = $title;
-    $this->id = preg_replace('/[^a-z0-9]+/', '_', strtolower($title));
+    $this->namespace = preg_replace('/[^A-Za-z0-9]+/', '_', $title);
+    $this->id = strtolower($this->namespace);
     $this->path = $path;
   }
 
@@ -48,13 +51,31 @@ class PatternkitDrupalTwigLib extends PatternkitDrupalCachedLib {
   /**
    * Returns the id of the Pattern Library.
    *
-   * The id also functions as the namespace for the twig templates.
-   *
    * @return string
    *   The Pattern Library id.
    */
   public function getId() {
     return $this->id;
+  }
+
+  /**
+   * Returns the case-sensitive namespace of the Pattern Library.
+   *
+   * @return string
+   *   The Pattern Library namespace.
+   */
+  public function getNamespace() {
+    return $this->namespace;
+  }
+
+  /**
+   * Returns the relative path of the Pattern Library.
+   *
+   * @return string
+   *   The Pattern Library path.
+   */
+  public function getPath() {
+    return $this->path;
   }
 
   /**
@@ -86,7 +107,7 @@ class PatternkitDrupalTwigLib extends PatternkitDrupalCachedLib {
     }
 
     $hostname = $_SERVER['HTTP_HOST'];
-    $namespace = $pattern->library->getId();
+    $id = $pattern->library->getId();
     $schema_json = drupal_json_encode($pattern->schema);
     $starting_json = $config !== NULL ? drupal_json_encode($config->fields)
       : array();
@@ -127,7 +148,7 @@ class PatternkitDrupalTwigLib extends PatternkitDrupalCachedLib {
 
       var r = new XMLHttpRequest(); 
             
-      var replacement = this.base_url + 'patternkit/ajax/$namespace/$1/schema$2';
+      var replacement = this.base_url + 'patternkit/ajax/$id/$1/schema$2';
       var uri = url.replace(/(\w+)\.json(#.*)/, replacement);
             
       r.open("GET", uri, true);
@@ -219,7 +240,7 @@ HTML;
 
     $it = new RecursiveDirectoryIterator($this->path);
     $filter = array('json', 'twig');
-    $namespace = $this->getId();
+    $id = $this->getId();
     $this->metadata = array();
     $components = array();
 
@@ -251,7 +272,7 @@ HTML;
     }
 
     foreach ($components as $module_name => $data) {
-      $subtype = "pk_{$namespace}_{$module_name}";
+      $subtype = "pk_{$id}_{$module_name}";
       // If the component has a json file, create the pattern from it.
       $schema = NULL;
       if (!empty($data['json']) && $file_contents = file_get_contents($data['json'])) {
@@ -279,7 +300,7 @@ HTML;
       // URL is redundant for the twig based components, so we use it to
       // store namespace.
       // @todo Revisit this usage.
-      $pattern->url = $this->getId();
+      $pattern->url = $this->getNamespace();
 
       if (!empty($data['twig'])) {
         $twig_file = $data['twig'];

--- a/src/PatternkitTwigWrapper.php
+++ b/src/PatternkitTwigWrapper.php
@@ -35,7 +35,7 @@ class PatternkitTwigWrapper {
   /**
    * PatternkitTwigWrapper constructor.
    *
-   * @param array $libraries
+   * @param \PatternkitDrupalTwigLib[] $libraries
    *   The collection of patterns and metadata.
    */
   protected function __construct(array $libraries) {
@@ -44,22 +44,21 @@ class PatternkitTwigWrapper {
     }
 
     $this->libraries = $libraries;
-
-    // Collect all metadata.
-    $this->metadata = array();
-
-    $meta = array();
-    foreach ($libraries as $library) {
-      $meta[] = $library->getCachedMetadata();
-    }
-    $this->metadata = call_user_func_array('array_merge', $meta);
-
     // Setup twig environment.
     // @TODO: Properly libraryize this.
     require_once DRUPAL_ROOT . '/sites/all/libraries/Twig/Autoloader.php';
     Twig_Autoloader::register();
 
     $loader = new Twig_Loader_Filesystem();
+
+    // Collect all metadata.
+    $this->metadata = array();
+    $meta = array();
+    foreach ($libraries as $library) {
+      $meta[] = $library->getCachedMetadata();
+      $loader->addPath($library->getPath(), $library->getNamespace());
+    }
+    $this->metadata = call_user_func_array('array_merge', $meta);
 
     foreach ($this->metadata as $module_name => $module) {
       if (!empty($module->filename)) {


### PR DESCRIPTION
feat(Twig)

Adds support for Twig templates to reference other loaded libraries via
namespace for functionality such as includes, embeds, macros etc.

Usage:
Just reference the library namespace as if the namespace was part of the
current library.
```
{% include '@myOtherLib/pattern/src/example.twig' %}
```