### PR TITLE
fix(patternkit.routing): Opt-out of route normalization

### DIFF
--- a/patternkit.routing.yml
+++ b/patternkit.routing.yml
@@ -27,6 +27,7 @@ patternkit.api:
   path: '/api/patternkit'
   defaults:
     _controller: '\Drupal\patternkit\Controller\PatternkitController::apiPattern'
+    _disable_route_normalizer: 'TRUE'
   requirements:
     _access: 'TRUE'
 patternkit.settings:


### PR DESCRIPTION
When global redirects are enabled and used in conjunction with
Translation Management or other modules that change URIs in Drupals
router we should opt-out of the enforcement for normalized paths.