### PR TITLE
Prevent unexpected error caused during cache clear.

### DIFF
--- a/src/Asset/PatternLibraryParser/FilePatternLibraryParser.php
+++ b/src/Asset/PatternLibraryParser/FilePatternLibraryParser.php
@@ -106,6 +106,9 @@ class FilePatternLibraryParser extends PatternLibraryParserBase {
     }
     $metadata = [];
     // @todo Grab the extension from the plugin.
+    if (!isset($library->toArray()['plugin'])) {
+      return [];
+    }
     $type = strtok($library->toArray()['plugin'], '.');
     if ($type !== 'file') {
       return [];


### PR DESCRIPTION
When clearing the cache, the file pattern library parser has an undefined index which causes an unexpected error during cache clear.