### PR TITLE
DAT-1017: Fixes loading block revisions

### DIFF
--- a/config/schema/patternkit.schema.yml
+++ b/config/schema/patternkit.schema.yml
@@ -37,6 +37,9 @@ block.settings.patternkit_block:*:
     patternkit_block_id:
       type: integer
       label: 'ID of the Patternkit Block content entity.'
+    patternkit_block_rid:
+      type: integer
+      label: 'Revision ID of the Patternkit Block content entity.'
     presentation_style:
       type: string
       label: 'Presentation style for the patternkit block when rendered.'

--- a/js/patternkit.jsoneditor.ckeditor.es6.js
+++ b/js/patternkit.jsoneditor.ckeditor.es6.js
@@ -124,6 +124,7 @@ export function patternkitEditorCKEditor($, Drupal, JSONEditor) {
       JSONEditor.defaults.resolvers.unshift(function (schema) {
         if (schema.type === 'string'
           && schema.format === 'html'
+          && schema.options
           && schema.options.wysiwyg
           && settings.patternkitEditor.theme === 'html') {
           return 'drupal_ckeditor';

--- a/js/patternkit.jsoneditor.js
+++ b/js/patternkit.jsoneditor.js
@@ -188,7 +188,7 @@ function patternkitEditorCKEditor($, Drupal, JSONEditor) {
       };
       JSONEditor.defaults.editors.drupal_ckeditor = DrupalCKEditor;
       JSONEditor.defaults.resolvers.unshift(function (schema) {
-        if (schema.type === 'string' && schema.format === 'html' && schema.options.wysiwyg && settings.patternkitEditor.theme === 'html') {
+        if (schema.type === 'string' && schema.format === 'html' && schema.options && schema.options.wysiwyg && settings.patternkitEditor.theme === 'html') {
           return 'drupal_ckeditor';
         }
       });
@@ -641,7 +641,7 @@ function patternkitEditorQuill($, Drupal, JSONEditor) {
       };
       JSONEditor.defaults.editors.drupal_quill = DrupalQuill;
       JSONEditor.defaults.resolvers.unshift(function (schema) {
-        if (schema.type === 'string' && schema.format === 'html' && schema.options.wysiwyg && settings.patternkitEditor.theme !== 'html') {
+        if (schema.type === 'string' && schema.format === 'html' && schema.options && schema.options.wysiwyg && settings.patternkitEditor.theme !== 'html') {
           return 'drupal_quill';
         }
       });

--- a/js/patternkit.jsoneditor.quill.es6.js
+++ b/js/patternkit.jsoneditor.quill.es6.js
@@ -126,6 +126,7 @@ export function patternkitEditorQuill($, Drupal, JSONEditor) {
       JSONEditor.defaults.resolvers.unshift(function (schema) {
         if (schema.type === 'string'
           && schema.format === 'html'
+          && schema.options
           && schema.options.wysiwyg
           && settings.patternkitEditor.theme !== 'html') {
           return 'drupal_quill';

--- a/tests/src/Functional/PatternkitTest.php
+++ b/tests/src/Functional/PatternkitTest.php
@@ -68,7 +68,8 @@ class PatternkitTest extends BrowserTestBase {
     $this->drupalPlaceBlock('patternkit_block:patternkit_atoms_example_src_example', [
       'region' => 'content',
       'pattern' => $pattern->getRevisionId(),
-      'patternkit_block_id' => $patternkit_block->id()
+      'patternkit_block_id' => $patternkit_block->id(),
+      'patternkit_block_rid' => $patternkit_block->getRevisionId(),
     ]);
 
     $assert = $this->assertSession();


### PR DESCRIPTION
fix(Plugin/Block/PatternkitBlock)

Resolves an issue where the latest block revision was loaded regardless
of how the configuration was set. While ->load should respect the
current revision, when layout builder is used, it does not source the
context of the loaded entity.