### PR TITLE
feat(PatternLibraryParser): Dereference schema definition refs

### DIFF
--- a/src/Asset/PatternLibraryParser/FilePatternLibraryParser.php
+++ b/src/Asset/PatternLibraryParser/FilePatternLibraryParser.php
@@ -147,14 +147,7 @@ class FilePatternLibraryParser extends PatternLibraryParserBase {
     }
 
     foreach ($metadata as $pattern_type => $pattern) {
-      // Replace any $ref links with relative paths.
-      if (!isset($pattern->schema['properties'])) {
-        continue;
-      }
-      $pattern->schema['properties'] = static::schemaDereference(
-        $pattern->schema['properties'],
-        $pattern
-      );
+      $pattern->schema = static::schemaDereference($pattern->schema, $pattern);
       $metadata[$pattern_type] = $pattern;
     }
     return $metadata;

--- a/src/Asset/PatternLibraryParser/JSONPatternLibraryParser.php
+++ b/src/Asset/PatternLibraryParser/JSONPatternLibraryParser.php
@@ -94,12 +94,7 @@ class JSONPatternLibraryParser extends PatternLibraryParserBase {
     foreach ($metadata as $pattern_type => $pattern) {
       // Replace any $ref links with relative paths.
       $schema = json_decode($pattern->getSchema(), TRUE);
-      if (isset($schema['properties'])) {
-        $schema['properties'] = static::schemaDereference(
-          $schema['properties'],
-          $pattern
-        );
-      }
+      $schema = static::schemaDereference($schema, $pattern);
       $pattern->setSchema($schema);
       $metadata[$pattern_type] = $pattern->toArray();
     }

--- a/src/Asset/PatternLibraryParser/TwigPatternLibraryParser.php
+++ b/src/Asset/PatternLibraryParser/TwigPatternLibraryParser.php
@@ -76,13 +76,7 @@ class TwigPatternLibraryParser extends PatternLibraryParserBase {
     $assets['schema'] = $assets['json'];
     // Replace any $ref links with relative paths.
     $schema = $this->serializer::decode($assets['schema']);
-    if (!isset($schema['properties'])) {
-      return $assets;
-    }
-    $schema['properties'] = static::schemaDereference(
-      $schema['properties'],
-      $pattern
-    );
+    $schema = static::schemaDereference($schema, $pattern);
     $assets['schema'] = $this->serializer::encode($schema);
     return $assets;
   }


### PR DESCRIPTION
Where existing code to dereference schema property references existed,
logic was added to do the same for references that are part of a
schema definitions object.