### PR TITLE
RHPC-1059: Set default values for new json editor-related settings.

### DIFF
--- a/patternkit.install
+++ b/patternkit.install
@@ -5,8 +5,8 @@
  * Install file for patternkit module.
  */
 
-use Drupal\Component\Serialization\Yaml;
 use Drupal\Core\Cache\Cache;
+use Drupal\Core\Config\FileStorage;
 use Drupal\Core\Entity\ContentEntityType;
 use Drupal\Core\Entity\EntityAccessControlHandler;
 use Drupal\Core\Entity\EntityListBuilder;
@@ -163,11 +163,10 @@ function patternkit_update_8003(&$sandbox) {
  */
 function patternkit_update_8004(&$sandbox) {
   $config_key = 'patternkit.settings';
-  $module_path = drupal_get_path('module', 'patternkit');
-  $config_install_path = file_get_contents($module_path . '/config/install/' . $config_key . '.yml');
-  $config_install = Yaml::decode($config_install_path);
-
+  $source = new FileStorage(drupal_get_path('module', 'patternkit') . '/config/install');
+  $config_install = $source->read($config_key);
   $config_current = \Drupal::configFactory()->getEditable($config_key);
+
   $new_keys = [
     'patternkit_json_editor_use_shadow_dom',
     'patternkit_json_editor_wysiwyg',

--- a/patternkit.install
+++ b/patternkit.install
@@ -5,6 +5,7 @@
  * Install file for patternkit module.
  */
 
+use Drupal\Component\Serialization\Yaml;
 use Drupal\Core\Cache\Cache;
 use Drupal\Core\Entity\ContentEntityType;
 use Drupal\Core\Entity\EntityAccessControlHandler;
@@ -155,4 +156,32 @@ function patternkit_update_8003(&$sandbox) {
   $entity_definition_update_manager
     ->installFieldStorageDefinition('pattern_id',
   'patternkit_block', 'patternkit', $pattern_id_field_definition);
+}
+
+/**
+ * Sets default values for new json-editor settings.
+ */
+function patternkit_update_8004(&$sandbox) {
+  $config_key = 'patternkit.settings';
+  $module_path = drupal_get_path('module', 'patternkit');
+  $config_install_path = file_get_contents($module_path . '/config/install/' . $config_key . '.yml');
+  $config_install = Yaml::decode($config_install_path);
+
+  $config_current = \Drupal::configFactory()->getEditable($config_key);
+  $new_keys = [
+    'patternkit_json_editor_use_shadow_dom',
+    'patternkit_json_editor_wysiwyg',
+    'patternkit_json_editor_ckeditor_toolbar',
+  ];
+  $changed = FALSE;
+  foreach ($new_keys as $new_key) {
+    if (is_null($config_current->get($new_key))) {
+      $config_current->set($new_key, $config_install[$new_key]);
+      $changed = TRUE;
+    }
+  }
+
+  if ($changed) {
+    $config_current->save();
+  }
 }

--- a/src/JSONSchemaEditorTrait.php
+++ b/src/JSONSchemaEditorTrait.php
@@ -3,6 +3,8 @@
 namespace Drupal\patternkit;
 
 use Drupal\ckeditor\Plugin\Editor\CKEditor;
+use Drupal\Core\Logger\LoggerChannelTrait;
+use Drupal\Core\Messenger\MessengerTrait;
 use Drupal\Core\Render\BubbleableMetadata;
 use Drupal\editor\Entity\Editor;
 use Drupal\patternkit\Form\PatternLibraryJSONForm;
@@ -11,6 +13,9 @@ use Drupal\patternkit\Form\PatternLibraryJSONForm;
  * Adds a schema editor render array generator without needing a full service.
  */
 trait JSONSchemaEditorTrait {
+
+  use MessengerTrait;
+  use LoggerChannelTrait;
 
   /**
    * Patternkit config.
@@ -118,22 +123,25 @@ trait JSONSchemaEditorTrait {
 
     if ($this->config->get('patternkit_json_editor_wysiwyg') == 'ckeditor') {
       $selected_toolbar = $this->config->get('patternkit_json_editor_ckeditor_toolbar');
+      if (!empty($selected_toolbar)) {
+        // The following code builds a CKEditor toolbar. Code stolen from
+        // \Drupal\editor\Element::preRenderTextFormat.
+        $ckeditor_instance = CKEditor::create(\Drupal::getContainer(), [], 'ckeditor', ['provider' => 'patternkit']);
+        /** @var \Drupal\editor\Entity\Editor $ckeditor_config */
+        $ckeditor_entity = Editor::load($selected_toolbar);
+        if ($ckeditor_entity && $ckeditor_entity->status()) {
+          $editor_settings['patternkitCKEditorConfig'] = $ckeditor_instance->getJSSettings($ckeditor_entity);
+          // Pushes the selected toolbar to drupalSettings, so that client-side so
+          // that DrupalCKEditor.afterInputReady
+          $editor_settings['patternkitCKEditorConfig']['selected_toolbar'] = $selected_toolbar;
+        }
+        else {
+          $msg = $this->t('Missing Editor entity @name', ['@name' => $selected_toolbar]);
+          $this->getLogger('patternkit')->error($msg);
+          $this->messenger()->addError($msg);
+        }
+      }
     }
-    if (empty($selected_toolbar)) {
-      $selected_toolbar = 'full_html';
-    }
-
-    // The following code builds a CKEditor toolbar. Code stolen from
-    // \Drupal\editor\Element::preRenderTextFormat.
-
-    $ckeditor_instance = CKEditor::create(\Drupal::getContainer(), [], 'ckeditor', ['provider' => 'patternkit']);
-    /** @var \Drupal\editor\Entity\Editor $ckeditor_config */
-    $ckeditor_entity = Editor::load($selected_toolbar);
-
-    $editor_settings['patternkitCKEditorConfig'] = $ckeditor_instance->getJSSettings($ckeditor_entity);
-    // Pushes the selected toolbar to drupalSettings, so that client-side so
-    // that DrupalCKEditor.afterInputReady
-    $editor_settings['patternkitCKEditorConfig']['selected_toolbar'] = $selected_toolbar;
 
     // @todo Move to own JS file & Drupal Settings config var.
     $element = [


### PR DESCRIPTION
Changes:

- Added an update hook to set default values for newer JSON Editor-related config options. This will help avoid errors on sites where patternkit module gets updated but is already enabled.
- Updated CKEditor integration to be more robust, so that a missing or disabled Drupal Text Editor entity does not cause fatal errors. If the selected Text Editor is missing or disabled, then CKEditor in Patternkit will be broken. However, the code will log messages to screen and watchdog to point the site builder to the problem.